### PR TITLE
Add slice

### DIFF
--- a/eiger_io/fs_handler.py
+++ b/eiger_io/fs_handler.py
@@ -139,7 +139,7 @@ class EigerHandler(HandlerBase):
 
         self._images_per_file = images_per_file
 
-    def __call__(self, seq_id, image_slice=None):
+    def __call__(self, seq_id, frame_num=None):
         '''
             This returns data contained in the file.
 
@@ -170,8 +170,8 @@ class EigerHandler(HandlerBase):
         md['framerate'] = 1./md['frame_time']
         # TODO Return a multi-dimensional PIMS seq.
         ret = EigerImages(master_path, self._images_per_file, md=md)
-        if image_slice is not None:
-            ret = ret[image_slice]
+        if frame_num is not None:
+            ret = ret[frame_num]
         return ret
 
     def get_file_list(self, datum_kwargs):

--- a/eiger_io/fs_handler.py
+++ b/eiger_io/fs_handler.py
@@ -169,7 +169,7 @@ class EigerHandler(HandlerBase):
         md['binary_mask'] = (pixel_mask == 0)
         md['framerate'] = 1./md['frame_time']
         # TODO Return a multi-dimensional PIMS seq.
-        ret EigerImages(master_path, self._images_per_file, md=md)
+        ret = EigerImages(master_path, self._images_per_file, md=md)
         if image_slice is not None:
             ret = ret[image_slice]
         return ret

--- a/eiger_io/fs_handler.py
+++ b/eiger_io/fs_handler.py
@@ -139,7 +139,7 @@ class EigerHandler(HandlerBase):
 
         self._images_per_file = images_per_file
 
-    def __call__(self, seq_id):
+    def __call__(self, seq_id, image_slice=None):
         '''
             This returns data contained in the file.
 
@@ -169,7 +169,10 @@ class EigerHandler(HandlerBase):
         md['binary_mask'] = (pixel_mask == 0)
         md['framerate'] = 1./md['frame_time']
         # TODO Return a multi-dimensional PIMS seq.
-        return EigerImages(master_path, self._images_per_file, md=md)
+        ret EigerImages(master_path, self._images_per_file, md=md)
+        if image_slice is not None:
+            ret = ret[image_slice]
+        return ret
 
     def get_file_list(self, datum_kwargs):
         ''' get the file list.

--- a/eiger_io/fs_handler_dask.py
+++ b/eiger_io/fs_handler_dask.py
@@ -167,14 +167,17 @@ class EigerHandlerDask(HandlerBase):
         self._base_path = fpath
 
     # this is on a per event level
-    def __call__(self, seq_id):
+    def __call__(self, seq_id, image_slice=None):
         master_path = '{}_{}_master.h5'.format(self._base_path, seq_id)
 
         data, md = _load_eiger_images(master_path)
         # PIMS subclass using Dask
         # this gives metadata and also makes the assumption when
         # to run .compute() for dask array
-        return PIMSDask(data, md=md)
+        ret = PIMSDask(data, md=md)
+        if image_slice is not None:
+            ret = ret[image_slice]
+        return ret
 
     def get_file_list(self, datum_kwargs):
         ''' get the file list.

--- a/eiger_io/fs_handler_dask.py
+++ b/eiger_io/fs_handler_dask.py
@@ -167,7 +167,7 @@ class EigerHandlerDask(HandlerBase):
         self._base_path = fpath
 
     # this is on a per event level
-    def __call__(self, seq_id, image_slice=None):
+    def __call__(self, seq_id, frame_num=None):
         master_path = '{}_{}_master.h5'.format(self._base_path, seq_id)
 
         data, md = _load_eiger_images(master_path)
@@ -175,8 +175,8 @@ class EigerHandlerDask(HandlerBase):
         # this gives metadata and also makes the assumption when
         # to run .compute() for dask array
         ret = PIMSDask(data, md=md)
-        if image_slice is not None:
-            ret = ret[image_slice]
+        if frame_num is not None:
+            ret = ret[frame_num]
         return ret
 
     def get_file_list(self, datum_kwargs):


### PR DESCRIPTION
Adding a slice kwarg to Eiger Handler. backwards compatible.
This is to satisfy a new mode we are trying in the acquisition from EIGER detectors.

```
dscan_manual([eiger4m_manual], start, stop, num, steps)
```
The problem is that currently, for every point in a scan, two files are generated:
```
-rw-rw-r--  1 softioc chx  88K Apr 26 13:49 db283daf-7526-4aa1-9399_830_data_000001.h5
-rw-rw-r--  1 softioc chx  87M Apr 26 13:49 db283daf-7526-4aa1-9399_830_master.h5
```
The first contains data but the second is overhead involving information on the detector.
Thus to read a file, all a handler needed to know was the file prefix and sequence number (i.e. "830").

Now, a dscan saves all events in the same hdf5 linked file group (i.e. we only have one 'master' file per set of events now). This requires a new keyword argument, the slice number which I define to be `image_slice` effectively done [here](https://github.com/NSLS-II-CHX/profile_collection/blob/c6ba0526610a465ac515dfaaac8111c4448b6c80/startup/20-area-detectors.py#L106).

I could have written two separate handlers but since there are almost no differences, I've combined them into one. I have however, added a new handler spec named `AD_EIGER_SLICE` just in case.


